### PR TITLE
Add support for websocket binary messages mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 VUE_APP_GUITARIX_HOST=127.0.0.1
 VUE_APP_GUITARIX_PORT=5000
 
+VUE_APP_WEBSOCKET_USE_BINARY_FORMAT=0
+
 # comma seperated
 VUE_APP_GUITARIX_IGNORE_FX=dubber,mbc,mbchor,mbclip,mbcs,mbd,mbdel,mbe,oscilloscope,seq
 


### PR DESCRIPTION
This commit adds support for websocket binary messages mode. Since modern versions of websockify from upstream [do not support](https://github.com/novnc/websockify/issues/365#issuecomment-432270758) text messages anymore, it's the only way to go if one does not plan to use outdated websockify version that is bundled with guitarix.